### PR TITLE
Increase support to 10 type arguments for generic classes

### DIFF
--- a/lib/src/type_switcher.dart
+++ b/lib/src/type_switcher.dart
@@ -9,8 +9,8 @@ class TypeSwitcher {
       if (fi.args.length != args.length) {
         throw ArgumentError(
             'Function expects different amount of type arguments. Provided ${args.length}, but expected ${fi.args.length}.');
-      } else if (args.length > 5) {
-        throw ArgumentError('TypePlus only supports generic functions with up to 5 type arguments.');
+      } else if (args.length > 10) {
+        throw ArgumentError('TypePlus only supports generic functions with up to 10 type arguments.');
       }
 
       if (fi.namedParams.isNotEmpty) {
@@ -20,8 +20,8 @@ class TypeSwitcher {
       } else if (params.length > fi.params.length + fi.optionalParams.length) {
         throw ArgumentError(
             "Function $fn must be called with at most ${fi.params.length + fi.optionalParams.length} parameters.");
-      } else if (params.length > 5) {
-        throw ArgumentError('TypePlus only supports generic functions with up to 5 parameters.');
+      } else if (params.length > 10) {
+        throw ArgumentError('TypePlus only supports generic functions with up to 10 parameters.');
       }
 
       return true;
@@ -34,6 +34,10 @@ class TypeSwitcher {
       Function<A, B, C>()? $3,
       Function<A, B, C, E>()? $4,
       Function<A, B, C, E, D>()? $5,
+      Function<A, B, C, E, D, F>()? $6,
+      Function<A, B, C, E, D, F, G>()? $7,
+      Function<A, B, C, E, D, F, G, H>()? $8,
+      Function<A, B, C, E, D, F, G, H, I>()? $9,
     }) {
       var a = [...args];
       dynamic call(Function next) {
@@ -56,6 +60,10 @@ class TypeSwitcher {
         3 => call(<A>() => call(<B>() => call(<C>() => $3?.call<A, B, C>()))),
         4 => call(<A>() => call(<B>() => call(<C>() => call(<D>() => $4?.call<A, B, C, D>())))),
         5 => call(<A>() => call(<B>() => call(<C>() => call(<D>() => call(<E>() => $5?.call<A, B, C, D, E>()))))),
+        6 => call(<A>() => call(<B>() => call(<C>() => call(<D>() => call(<E>() => call(<F>() => $6?.call<A, B, C, D, E, F>())))))),
+        7 => call(<A>() => call(<B>() => call(<C>() => call(<D>() => call(<E>() => call(<F>() => call(<G>() => $7?.call<A, B, C, D, E, F, G>()))))))),
+        8 => call(<A>() => call(<B>() => call(<C>() => call(<D>() => call(<E>() => call(<F>() => call(<G>() => call(<H>() => $8?.call<A, B, C, D, E, F, G, H>())))))))),
+        9 => call(<A>() => call(<B>() => call(<C>() => call(<D>() => call(<E>() => call(<F>() => call(<G>() => call(<H>() => call(<I>() => $9?.call<A, B, C, D, E, F, G, H, I>()))))))))),
         _ => throw ArgumentError('TypePlus only supports generic functions with up to 5 type arguments.'),
       };
     }
@@ -67,6 +75,10 @@ class TypeSwitcher {
       Function(dynamic, dynamic, dynamic)? $3,
       Function(dynamic, dynamic, dynamic, dynamic)? $4,
       Function(dynamic, dynamic, dynamic, dynamic, dynamic)? $5,
+      Function(dynamic, dynamic, dynamic, dynamic, dynamic, dynamic)? $6,
+      Function(dynamic, dynamic, dynamic, dynamic, dynamic, dynamic, dynamic)? $7,
+      Function(dynamic, dynamic, dynamic, dynamic, dynamic, dynamic, dynamic, dynamic)? $8,
+      Function(dynamic, dynamic, dynamic, dynamic, dynamic, dynamic, dynamic, dynamic, dynamic)? $9,
     }) {
       return switch (params) {
         [] => $0?.call(),
@@ -75,7 +87,11 @@ class TypeSwitcher {
         [var a, var b, var c] => $3?.call(a, b, c),
         [var a, var b, var c, var d] => $4?.call(a, b, c, d),
         [var a, var b, var c, var d, var e] => $5?.call(a, b, c, d, e),
-        _ => throw ArgumentError('TypePlus only supports generic functions with up to 5 parameters.'),
+        [var a, var b, var c, var d, var e, var f] => $6?.call(a, b, c, d, e, f),
+        [var a, var b, var c, var d, var e, var f, var g] => $7?.call(a, b, c, d, e, f, g),
+        [var a, var b, var c, var d, var e, var f, var g, var h] => $8?.call(a, b, c, d, e, f, g, h),
+        [var a, var b, var c, var d, var e, var f, var g, var h, var i] => $9?.call(a, b, c, d, e, f, g, h, i),
+        _ => throw ArgumentError('TypePlus only supports generic functions with up to 10 parameters.'),
       };
     }
 
@@ -87,6 +103,10 @@ class TypeSwitcher {
         $3: (a, b, c) => fn(a, b, c),
         $4: (a, b, c, d) => fn(a, b, c, d),
         $5: (a, b, c, d, e) => fn(a, b, c, d, e),
+        $6: (a, b, c, d, e, f) => fn(a, b, c, d, e, f),
+        $7: (a, b, c, d, e, f, g) => fn(a, b, c, d, e, f, g),
+        $8: (a, b, c, d, e, f, g, h) => fn(a, b, c, d, e, f, g, h),
+        $9: (a, b, c, d, e, f, g, h, i) => fn(a, b, c, d, e, f, g, h, i),
       ),
       $1: <A>() => $params(
         $0: () => fn<A>(),
@@ -95,6 +115,10 @@ class TypeSwitcher {
         $3: (a, b, c) => fn<A>(a, b, c),
         $4: (a, b, c, d) => fn<A>(a, b, c, d),
         $5: (a, b, c, d, e) => fn<A>(a, b, c, d, e),
+        $6: (a, b, c, d, e, f) => fn<A>(a, b, c, d, e, f),
+        $7: (a, b, c, d, e, f, g) => fn<A>(a, b, c, d, e, f, g),
+        $8: (a, b, c, d, e, f, g, h) => fn<A>(a, b, c, d, e, f, g, h),
+        $9: (a, b, c, d, e, f, g, h, i) => fn<A>(a, b, c, d, e, f, g, h, i),
       ),
       $2: <A, B>() => $params(
         $0: () => fn<A, B>(),
@@ -103,6 +127,10 @@ class TypeSwitcher {
         $3: (a, b, c) => fn<A, B>(a, b, c),
         $4: (a, b, c, d) => fn<A, B>(a, b, c, d),
         $5: (a, b, c, d, e) => fn<A, B>(a, b, c, d, e),
+        $6: (a, b, c, d, e, f) => fn<A, B>(a, b, c, d, e, f),
+        $7: (a, b, c, d, e, f, g) => fn<A, B>(a, b, c, d, e, f, g),
+        $8: (a, b, c, d, e, f, g, h) => fn<A, B>(a, b, c, d, e, f, g, h),
+        $9: (a, b, c, d, e, f, g, h, i) => fn<A, B>(a, b, c, d, e, f, g, h, i),
       ),
       $3: <A, B, C>() => $params(
         $0: () => fn<A, B, C>(),
@@ -111,6 +139,10 @@ class TypeSwitcher {
         $3: (a, b, c) => fn<A, B, C>(a, b, c),
         $4: (a, b, c, d) => fn<A, B, C>(a, b, c, d),
         $5: (a, b, c, d, e) => fn<A, B, C>(a, b, c, d, e),
+        $6: (a, b, c, d, e, f) => fn<A, B, C>(a, b, c, d, e, f),
+        $7: (a, b, c, d, e, f, g) => fn<A, B, C>(a, b, c, d, e, f, g),
+        $8: (a, b, c, d, e, f, g, h) => fn<A, B, C>(a, b, c, d, e, f, g, h),
+        $9: (a, b, c, d, e, f, g, h, i) => fn<A, B, C>(a, b, c, d, e, f, g, h, i),
       ),
       $4: <A, B, C, D>() => $params(
         $0: () => fn<A, B, C, D>(),
@@ -119,6 +151,10 @@ class TypeSwitcher {
         $3: (a, b, c) => fn<A, B, C, D>(a, b, c),
         $4: (a, b, c, d) => fn<A, B, C, D>(a, b, c, d),
         $5: (a, b, c, d, e) => fn<A, B, C, D>(a, b, c, d, e),
+        $6: (a, b, c, d, e, f) => fn<A, B, C, D>(a, b, c, d, e, f),
+        $7: (a, b, c, d, e, f, g) => fn<A, B, C, D>(a, b, c, d, e, f, g),
+        $8: (a, b, c, d, e, f, g, h) => fn<A, B, C, D>(a, b, c, d, e, f, g, h),
+        $9: (a, b, c, d, e, f, g, h, i) => fn<A, B, C, D>(a, b, c, d, e, f, g, h, i),
       ),
       $5: <A, B, C, D, E>() => $params(
         $0: () => fn<A, B, C, D, E>(),
@@ -127,6 +163,58 @@ class TypeSwitcher {
         $3: (a, b, c) => fn<A, B, C, D, E>(a, b, c),
         $4: (a, b, c, d) => fn<A, B, C, D, E>(a, b, c, d),
         $5: (a, b, c, d, e) => fn<A, B, C, D, E>(a, b, c, d, e),
+        $6: (a, b, c, d, e, f) => fn<A, B, C, D, E>(a, b, c, d, e, f),
+        $7: (a, b, c, d, e, f, g) => fn<A, B, C, D, E>(a, b, c, d, e, f, g),
+        $8: (a, b, c, d, e, f, g, h) => fn<A, B, C, D, E>(a, b, c, d, e, f, g, h),
+        $9: (a, b, c, d, e, f, g, h, i) => fn<A, B, C, D, E>(a, b, c, d, e, f, g, h, i),
+      ),
+      $6: <A, B, C, D, E, F>() => $params(
+        $0: () => fn<A, B, C, D, E, F>(),
+        $1: (a) => fn<A, B, C, D, E, F>(a),
+        $2: (a, b) => fn<A, B, C, D, E, F>(a, b),
+        $3: (a, b, c) => fn<A, B, C, D, E, F>(a, b, c),
+        $4: (a, b, c, d) => fn<A, B, C, D, E, F>(a, b, c, d),
+        $5: (a, b, c, d, e) => fn<A, B, C, D, E, F>(a, b, c, d, e),
+        $6: (a, b, c, d, e, f) => fn<A, B, C, D, E, F>(a, b, c, d, e, f),
+        $7: (a, b, c, d, e, f, g) => fn<A, B, C, D, E, F>(a, b, c, d, e, f, g),
+        $8: (a, b, c, d, e, f, g, h) => fn<A, B, C, D, E, F>(a, b, c, d, e, f, g, h),
+        $9: (a, b, c, d, e, f, g, h, i) => fn<A, B, C, D, E, F>(a, b, c, d, e, f, g, h, i),
+      ),
+      $7: <A, B, C, D, E, F, G>() => $params(
+        $0: () => fn<A, B, C, D, E, F, G>(),
+        $1: (a) => fn<A, B, C, D, E, F, G>(a),
+        $2: (a, b) => fn<A, B, C, D, E, F, G>(a, b),
+        $3: (a, b, c) => fn<A, B, C, D, E, F, G>(a, b, c),
+        $4: (a, b, c, d) => fn<A, B, C, D, E, F, G>(a, b, c, d),
+        $5: (a, b, c, d, e) => fn<A, B, C, D, E, F, G>(a, b, c, d, e),
+        $6: (a, b, c, d, e, f) => fn<A, B, C, D, E, F, G>(a, b, c, d, e, f),
+        $7: (a, b, c, d, e, f, g) => fn<A, B, C, D, E, F, G>(a, b, c, d, e, f, g),
+        $8: (a, b, c, d, e, f, g, h) => fn<A, B, C, D, E, F, G>(a, b, c, d, e, f, g, h),
+        $9: (a, b, c, d, e, f, g, h, i) => fn<A, B, C, D, E, F, G>(a, b, c, d, e, f, g, h, i),
+      ),
+      $8: <A, B, C, D, E, F, G, H>() => $params(
+        $0: () => fn<A, B, C, D, E, F, G, H>(),
+        $1: (a) => fn<A, B, C, D, E, F, G, H>(a),
+        $2: (a, b) => fn<A, B, C, D, E, F, G, H>(a, b),
+        $3: (a, b, c) => fn<A, B, C, D, E, F, G, H>(a, b, c),
+        $4: (a, b, c, d) => fn<A, B, C, D, E, F, G, H>(a, b, c, d),
+        $5: (a, b, c, d, e) => fn<A, B, C, D, E, F, G, H>(a, b, c, d, e),
+        $6: (a, b, c, d, e, f) => fn<A, B, C, D, E, F, G, H>(a, b, c, d, e, f),
+        $7: (a, b, c, d, e, f, g) => fn<A, B, C, D, E, F, G, H>(a, b, c, d, e, f, g),
+        $8: (a, b, c, d, e, f, g, h) => fn<A, B, C, D, E, F, G, H>(a, b, c, d, e, f, g, h),
+        $9: (a, b, c, d, e, f, g, h, i) => fn<A, B, C, D, E, F, G, H>(a, b, c, d, e, f, g, h, i),
+      ),
+      $9: <A, B, C, D, E, F, G, H, I>() => $params(
+        $0: () => fn<A, B, C, D, E, F, G, H, I>(),
+        $1: (a) => fn<A, B, C, D, E, F, G, H, I>(a),
+        $2: (a, b) => fn<A, B, C, D, E, F, G, H, I>(a, b),
+        $3: (a, b, c) => fn<A, B, C, D, E, F, G, H, I>(a, b, c),
+        $4: (a, b, c, d) => fn<A, B, C, D, E, F, G, H, I>(a, b, c, d),
+        $5: (a, b, c, d, e) => fn<A, B, C, D, E, F, G, H, I>(a, b, c, d, e),
+        $6: (a, b, c, d, e, f) => fn<A, B, C, D, E, F, G, H, I>(a, b, c, d, e, f),
+        $7: (a, b, c, d, e, f, g) => fn<A, B, C, D, E, F, G, H, I>(a, b, c, d, e, f, g),
+        $8: (a, b, c, d, e, f, g, h) => fn<A, B, C, D, E, F, G, H, I>(a, b, c, d, e, f, g, h),
+        $9: (a, b, c, d, e, f, g, h, i) => fn<A, B, C, D, E, F, G, H, I>(a, b, c, d, e, f, g, h, i),
       ),
     );
   }

--- a/lib/src/unresolved_type.dart
+++ b/lib/src/unresolved_type.dart
@@ -10,7 +10,11 @@ class UnresolvedType {
       3 => <A, B, C>(f) => f<UnresolvedType>(),
       4 => <A, B, C, D>(f) => f<UnresolvedType>(),
       5 => <A, B, C, D, E>(f) => f<UnresolvedType>(),
-      _ => throw Exception('TypePlus only supports generic classes with up to 5 type arguments.'),
+      6 => <A, B, C, D, E, F>(f) => f<UnresolvedType>(),
+      7 => <A, B, C, D, E, F, G>(f) => f<UnresolvedType>(),
+      8 => <A, B, C, D, E, F, G, H>(f) => f<UnresolvedType>(),
+      9 => <A, B, C, D, E, F, G, H, I>(f) => f<UnresolvedType>(),
+      _ => throw Exception('TypePlus only supports generic classes with up to 10 type arguments.'),
     };
   }
 }


### PR DESCRIPTION
TypePlus currently support a generic class with at most 5 arguments.
https://github.com/schultek/type_plus/blob/c4a542b5f79e312ceb9f747a3dbfd2b565b40d26/lib/src/unresolved_type.dart#L4-L16

In our codebase we have a class with 7 generics that we want to encode using `dart_mappable`, but we currently can't encode it without applying a patch to the `UnresolvedType` factory.

We would appreciate it if you could consider supporting up to 10 type arguments as the PR does.