### PR TITLE
Whitespaces bug on generic type arguments

### DIFF
--- a/test/type_info_test.dart
+++ b/test/type_info_test.dart
@@ -82,5 +82,23 @@ void main() {
         }),
       );
     });
+
+    test("Whitespace bug", () {
+      Type a = Map;
+      Type b = int;
+      
+      Type withoutSpaceAfterComma = TypePlus.fromId('${a.id}<${b.id},${b.id}>');
+      Type oneSpaceAfterComma = TypePlus.fromId('${a.id}<${b.id}, ${b.id}>');
+      Type twoSpaceAfterComma = TypePlus.fromId('${a.id}<${b.id},  ${b.id}>');
+      Type spaceAroundComma = TypePlus.fromId('${a.id}<${b.id} , ${b.id}>');
+
+      expect(withoutSpaceAfterComma.base, a);
+      withoutSpaceAfterComma.args.forEach((element) => expect(element, b));
+
+      expect(oneSpaceAfterComma, withoutSpaceAfterComma);
+      expect(twoSpaceAfterComma, withoutSpaceAfterComma);
+      expect(spaceAroundComma, withoutSpaceAfterComma);
+
+    });
   });
 }


### PR DESCRIPTION
Still using `dart_mappable` we found a bug that caused the decoding of a type from a string to fail.

For example, if for some reason the type in the json to be decoded was written without considering spaces then the decoding would strangely fail. 

After a bit of debugging we understood that the cause was the `fromId` method of `TypePlus`, in fact the "lexer" only accepts well-formatted types so for example:

```dart
Map<int, int>   // OK
Map<int,int>    // FAIL
Map<int , int>  // FAIL
Map<int ,int>   // FAIL
```

In b93255fef0d15bd907d834d71159f1ca52105288 we added a failing test case to better highlight the bug.

While in 9fb81a7fdd14361a8372d8f25c65479340839119 a solution is proposed that removes spaces around commas and angle brackets.

This is not the definitive solution but at least it handles generics more robustly. In my opinion the "lexer" in general should be improved.

P.S. This is the second bug we found, so we deserve at least two cookies 😄 
<img width="756" alt="Screenshot 2023-10-05 at 17 27 37" src="https://github.com/schultek/type_plus/assets/23644210/cd041b1e-6703-4239-ac2f-178a683067ef">
